### PR TITLE
Adding a miryoku keymap for the Redox Wireless

### DIFF
--- a/keyboards/redox_w/keymaps/manna-harbour_miryoku/config.h
+++ b/keyboards/redox_w/keymaps/manna-harbour_miryoku/config.h
@@ -5,15 +5,15 @@
 #define XXX KC_NO
 
 #define LAYOUT_miryoku(\
-     K00, K01, K02, K03, K04,               K05, K06, K07, K08, K09,\
-     K10, K11, K12, K13, K14,               K15, K16, K17, K18, K19,\
-     K20, K21, K22, K23, K24,               K25, K26, K27, K28, K29,\
-     N30, N31, K32, K33, K34,               K35, K36, K37, N38, N39\
+     K00, K01, K02, K03, K04,                          K05, K06, K07, K08, K09,\
+     K10, K11, K12, K13, K14,                          K15, K16, K17, K18, K19,\
+     K20, K21, K22, K23, K24,                          K25, K26, K27, K28, K29,\
+     N30, N31, K32, K33, K34,                          K35, K36, K37, N38, N39\
 )\
 LAYOUT(\
-XXX, XXX, XXX, XXX, XXX, XXX,                         XXX, XXX, XXX, XXX, XXX, XXX,\
-XXX, K00, K01, K02, K03, K04, XXX,               XXX, K05, K06, K07, K08, K09, XXX,\
-XXX, K10, K11, K12, K13, K14, XXX,               XXX, K15, K16, K17, K18, K19, XXX,\
-XXX, K20, K21, K22, K23, K24, XXX, XXX,     XXX, XXX, K25, K26, K27, K28, K29, XXX,\
-XXX, XXX, XXX, XXX,    K32,   K33, K34,     K35, K36,    K37,   XXX, XXX, XXX, XXX\
+XXX, XXX, XXX, XXX, XXX, XXX,                          XXX, XXX, XXX, XXX, XXX, XXX,\
+XXX, K00, K01, K02, K03, K04, XXX,                XXX, K05, K06, K07, K08, K09, XXX,\
+XXX, K10, K11, K12, K13, K14, XXX,                XXX, K15, K16, K17, K18, K19, XXX,\
+XXX, K20, K21, K22, K23, K24, XXX, XXX,      XXX, XXX, K25, K26, K27, K28, K29, XXX,\
+XXX, XXX, XXX, XXX,    K32,   K33, K34,      K35, K36,    K37,   XXX, XXX, XXX, XXX\
 )

--- a/keyboards/redox_w/keymaps/manna-harbour_miryoku/config.h
+++ b/keyboards/redox_w/keymaps/manna-harbour_miryoku/config.h
@@ -1,0 +1,19 @@
+// generated from users/manna-harbour_miryoku/miryoku.org  -*- buffer-read-only: t -*-
+
+#pragma once
+
+#define XXX KC_NO
+
+#define LAYOUT_miryoku(\
+     K00, K01, K02, K03, K04,               K05, K06, K07, K08, K09,\
+     K10, K11, K12, K13, K14,               K15, K16, K17, K18, K19,\
+     K20, K21, K22, K23, K24,               K25, K26, K27, K28, K29,\
+     N30, N31, K32, K33, K34,               K35, K36, K37, N38, N39\
+)\
+LAYOUT(\
+XXX, XXX, XXX, XXX, XXX, XXX,                         XXX, XXX, XXX, XXX, XXX, XXX,\
+XXX, K00, K01, K02, K03, K04, XXX,               XXX, K05, K06, K07, K08, K09, XXX,\
+XXX, K10, K11, K12, K13, K14, XXX,               XXX, K15, K16, K17, K18, K19, XXX,\
+XXX, K20, K21, K22, K23, K24, XXX, XXX,     XXX, XXX, K25, K26, K27, K28, K29, XXX,\
+XXX, XXX, XXX, XXX,    K32,   K33, K34,     K35, K36,    K37,   XXX, XXX, XXX, XXX\
+)

--- a/keyboards/redox_w/keymaps/manna-harbour_miryoku/keymap.c
+++ b/keyboards/redox_w/keymaps/manna-harbour_miryoku/keymap.c
@@ -1,0 +1,1 @@
+// generated from users/manna-harbour_miryoku/miryoku.org  -*- buffer-read-only: t -*-

--- a/users/manna-harbour_miryoku/miryoku.org
+++ b/users/manna-harbour_miryoku/miryoku.org
@@ -1431,17 +1431,17 @@ Contains subset mapping.
 #define XXX KC_NO
 
 #define LAYOUT_miryoku(\
-     K00, K01, K02, K03, K04,               K05, K06, K07, K08, K09,\
-     K10, K11, K12, K13, K14,               K15, K16, K17, K18, K19,\
-     K20, K21, K22, K23, K24,               K25, K26, K27, K28, K29,\
-     N30, N31, K32, K33, K34,               K35, K36, K37, N38, N39\
+     K00, K01, K02, K03, K04,                          K05, K06, K07, K08, K09,\
+     K10, K11, K12, K13, K14,                          K15, K16, K17, K18, K19,\
+     K20, K21, K22, K23, K24,                          K25, K26, K27, K28, K29,\
+     N30, N31, K32, K33, K34,                          K35, K36, K37, N38, N39\
 )\
 LAYOUT(\
-XXX, XXX, XXX, XXX, XXX, XXX,                         XXX, XXX, XXX, XXX, XXX, XXX,\
-XXX, K00, K01, K02, K03, K04, XXX,               XXX, K05, K06, K07, K08, K09, XXX,\
-XXX, K10, K11, K12, K13, K14, XXX,               XXX, K15, K16, K17, K18, K19, XXX,\
-XXX, K20, K21, K22, K23, K24, XXX, XXX,     XXX, XXX, K25, K26, K27, K28, K29, XXX,\
-XXX, XXX, XXX, XXX,    K32,   K33, K34,     K35, K36,    K37,   XXX, XXX, XXX, XXX\
+XXX, XXX, XXX, XXX, XXX, XXX,                          XXX, XXX, XXX, XXX, XXX, XXX,\
+XXX, K00, K01, K02, K03, K04, XXX,                XXX, K05, K06, K07, K08, K09, XXX,\
+XXX, K10, K11, K12, K13, K14, XXX,                XXX, K15, K16, K17, K18, K19, XXX,\
+XXX, K20, K21, K22, K23, K24, XXX, XXX,      XXX, XXX, K25, K26, K27, K28, K29, XXX,\
+XXX, XXX, XXX, XXX,    K32,   K33, K34,      K35, K36,    K37,   XXX, XXX, XXX, XXX\
 )
 #+END_SRC
 

--- a/users/manna-harbour_miryoku/miryoku.org
+++ b/users/manna-harbour_miryoku/miryoku.org
@@ -61,6 +61,7 @@ Additional implementations and visualisations are provided outside QMK in the
     - [[#kyria][kyria]]
     - [[#lily58][lily58]]
     - [[#moonlander][moonlander]]
+    - [[#redox_w][redox_w]]
   - [[#customisation][Customisation]]
 - [[#documentation][Documentation]]
 - [[#contact][Contact]]
@@ -1403,6 +1404,55 @@ XXX, XXX, XXX, XXX, XXX,      XXX,     XXX,      XXX, XXX, XXX, XXX, XXX,\
 Required by the build system.
 
 #+BEGIN_SRC C :noweb yes :padline no :tangle ../../keyboards/moonlander/keymaps/manna-harbour_miryoku/keymap.c
+// <<header>>
+#+END_SRC
+
+
+*** redox_w
+
+Only the main 5x3 alphas and the main 3 thumb keys are used.
+
+To build for this keyboard,
+
+#+BEGIN_SRC sh :tangle no
+make redox_w:manna-harbour_miryoku:flash
+#+END_SRC
+
+
+**** [[../../keyboards/redox_w/keymaps/manna-harbour_miryoku/config.h][keyboards/redox_w/keymaps/manna-harbour_miryoku/config.h]]
+
+Contains subset mapping.
+
+#+BEGIN_SRC C :noweb yes :padline no :tangle ../../keyboards/redox_w/keymaps/manna-harbour_miryoku/config.h
+// <<header>>
+
+#pragma once
+
+#define XXX KC_NO
+
+#define LAYOUT_miryoku(\
+     K00, K01, K02, K03, K04,               K05, K06, K07, K08, K09,\
+     K10, K11, K12, K13, K14,               K15, K16, K17, K18, K19,\
+     K20, K21, K22, K23, K24,               K25, K26, K27, K28, K29,\
+     N30, N31, K32, K33, K34,               K35, K36, K37, N38, N39\
+)\
+LAYOUT(\
+XXX, XXX, XXX, XXX, XXX, XXX,                         XXX, XXX, XXX, XXX, XXX, XXX,\
+XXX, K00, K01, K02, K03, K04, XXX,               XXX, K05, K06, K07, K08, K09, XXX,\
+XXX, K10, K11, K12, K13, K14, XXX,               XXX, K15, K16, K17, K18, K19, XXX,\
+XXX, K20, K21, K22, K23, K24, XXX, XXX,     XXX, XXX, K25, K26, K27, K28, K29, XXX,\
+XXX, XXX, XXX, XXX,    K32,   K33, K34,     K35, K36,    K37,   XXX, XXX, XXX, XXX\
+)
+#+END_SRC
+
+#+RESULTS:
+
+
+**** [[../../keyboards/redox_w/keymaps/manna-harbour_miryoku/keymap.c][keyboards/redox_w/keymaps/manna-harbour_miryoku/keymap.c]]
+
+Required by the build system.
+
+#+BEGIN_SRC C :noweb yes :padline no :tangle ../../keyboards/redox_w/keymaps/manna-harbour_miryoku/keymap.c
 // <<header>>
 #+END_SRC
 


### PR DESCRIPTION
## Description

Adding a miryoku keymap for the Redox Wireless.
I had some trouble generating the file using Doom Emacs. If you could confirm the files generate properly for you and still compile via `make` that would be appreciated.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
