### PR TITLE
Add a split_3x6_4 layout

### DIFF
--- a/layouts/community/split_3x6_4/manna-harbour_miryoku/config.h
+++ b/layouts/community/split_3x6_4/manna-harbour_miryoku/config.h
@@ -1,0 +1,16 @@
+// generated from users/manna-harbour_miryoku/miryoku.org  -*- buffer-read-only: t -*-
+
+#pragma once
+
+#define LAYOUT_miryoku(\
+       K00,   K01,   K02,   K03,   K04,          K05,   K06,   K07,   K08,   K09,\
+       K10,   K11,   K12,   K13,   K14,          K15,   K16,   K17,   K18,   K19,\
+       K20,   K21,   K22,   K23,   K24,          K25,   K26,   K27,   K28,   K29,\
+       N30,   N31,   K32,   K33,   K34,          K35,   K36,   K37,   N38,   N39\
+)\
+LAYOUT_split_3x6_4(\
+KC_NO, K00,   K01,   K02,   K03,   K04,          K05,   K06,   K07,   K08,   K09,   KC_NO,\
+KC_NO, K10,   K11,   K12,   K13,   K14,          K15,   K16,   K17,   K18,   K19,   KC_NO,\
+KC_NO, K20,   K21,   K22,   K23,   K24,          K25,   K26,   K27,   K28,   K29,   KC_NO,\
+              KC_NO, K32,   K33,   K34,          K35,   K36,   K37,   KC_NO\
+)

--- a/layouts/community/split_3x6_4/manna-harbour_miryoku/keymap.c
+++ b/layouts/community/split_3x6_4/manna-harbour_miryoku/keymap.c
@@ -1,0 +1,1 @@
+// generated from users/manna-harbour_miryoku/miryoku.org  -*- buffer-read-only: t -*-

--- a/users/manna-harbour_miryoku/miryoku.org
+++ b/users/manna-harbour_miryoku/miryoku.org
@@ -64,6 +64,7 @@ Additional implementations and visualisations are provided outside QMK in the
     - [[#planck_mit][planck_mit]]
     - [[#split_3x5_3][split_3x5_3]]
     - [[#split_3x6_3][split_3x6_3]]
+    - [[#split_3x6_4][split_3x6_4]]
   - [[#keyboards][Keyboards]]
     - [[#atreus][atreus]]
     - [[#dactyl_manuform4x5][dactyl_manuform/4x5]]
@@ -1277,6 +1278,42 @@ Required by the build system.
 #+BEGIN_SRC C :noweb yes :padline no :tangle ../../layouts/community/split_3x6_3/manna-harbour_miryoku/keymap.c
 // <<header>>
 #+END_SRC
+
+
+*** split_3x6_4
+
+The outer columns and inner thumb key are unused.
+
+To build for any keyboard using the this layout e.g. torn,
+
+#+BEGIN_SRC sh :tangle no
+make torn:manna-harbour_miryoku:flash
+#+END_SRC
+
+
+**** [[../../layouts/community/split_3x6_4/manna-harbour_miryoku/config.h][layouts/community/split_3x6_4/manna-harbour_miryoku/config.h]]
+
+Contains subset mapping.
+
+#+BEGIN_SRC C :noweb yes :padline no :tangle ../../layouts/community/split_3x6_4/manna-harbour_miryoku/config.h
+// <<header>>
+
+#pragma once
+
+#define LAYOUT_miryoku(K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, N30, N31, K32, K33, K34, K35, K36, K37, N38, N39) LAYOUT_split_3x6_4(KC_NO, K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, KC_NO, KC_NO, K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, KC_NO, KC_NO, K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, KC_NO, KC_NO, K32, K33, K34, K35, K36, K37, KC_NO)
+#+END_SRC
+
+#+RESULTS:
+
+
+**** [[../../layouts/community/split_3x6_4/manna-harbour_miryoku/keymap.c][layouts/community/split_3x6_4/manna-harbour_miryoku/keymap.c]]
+
+Required by the build system.
+
+#+BEGIN_SRC C :noweb yes :padline no :tangle ../../layouts/community/split_3x6_4/manna-harbour_miryoku/keymap.c
+// <<header>>
+#+END_SRC
+
 
 
 ** Keyboards


### PR DESCRIPTION
This layout is used by keyboards like the torn.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation
