### PR TITLE
unilateral mod-tap shouldn't send KC_GUI to computer

### DIFF
--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -197,16 +197,18 @@ If `BILATERAL_COMBINATIONS` is defined to a value, hold times greater than that 
 #define BILATERAL_COMBINATIONS 500
 ```
 
-To suppress "flashing mods" such as the GUI keys (which pop up the "Start Menu" in Microsoft Windows) during bilateral combinations, add the following to your `config.h`:
+To delay the registration of modifiers (such as `KC_LGUI` and `KC_RGUI`, which are considered to be "flashing mods" because they suddenly "flash" or pop up the "Start Menu" in Microsoft Windows) during bilateral combinations:
+
+1. Add the following line to your `config.h` and define a timeout value (measured in milliseconds).  Hold times greater than this value will permit modifiers to be registered.
 
 ```c
-#define BILATERAL_COMBINATIONS_FLASHMODS MOD_MASK_GUI
+#define BILATERAL_COMBINATIONS_DEFERMODS 100
 ```
 
-In addition, to also suppress the Alt keys (which pop up the "Ribbon Menu" in Microsoft Office) during bilateral combinations, specify a compound mask.  For example:
+2. Add the following line to your `rules.mk` file to enable QMK's deferred execution facility, which is needed by the `BILATERAL_COMBINATIONS_DEFERMODS` setting mentioned above.
 
-```c
-#define BILATERAL_COMBINATIONS_FLASHMODS (MOD_MASK_GUI|MOD_MASK_ALT)
+```make
+DEFERRED_EXEC_ENABLE = yes
 ```
 
 To monitor activations in the background, enable debugging, enable the console, enable terminal bell, add `#define DEBUG_ACTION` to `config.h`, and use something like the following shell command line:

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -197,6 +197,18 @@ If `BILATERAL_COMBINATIONS` is defined to a value, hold times greater than that 
 #define BILATERAL_COMBINATIONS 500
 ```
 
+To suppress "flashing mods" such as the GUI keys (which pop up the "Start Menu" in Microsoft Windows) during bilateral combinations, add the following to your `config.h`:
+
+```c
+#define BILATERAL_COMBINATIONS_FLASHMODS MOD_MASK_GUI
+```
+
+In addition, to also suppress the Alt keys (which pop up the "Ribbon Menu" in Microsoft Office) during bilateral combinations, specify a compound mask.  For example:
+
+```c
+#define BILATERAL_COMBINATIONS_FLASHMODS (MOD_MASK_GUI|MOD_MASK_ALT)
+```
+
 To monitor activations in the background, enable debugging, enable the console, enable terminal bell, add `#define DEBUG_ACTION` to `config.h`, and use something like the following shell command line:
 
 ```sh

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -263,12 +263,14 @@ static void bilateral_combinations_hold(action_t action, keyevent_t event) {
 static void bilateral_combinations_release(uint8_t code) {
     dprint("BILATERAL_COMBINATIONS: release\n");
     if (bilateral_combinations.active && (code == bilateral_combinations.code)) {
-        if (bilateral_combinations.mods & MOD_MASK_GUI) {
-          // Send a single tap of the GUI modifiers to the computer which we
-          // suppressed earlier, before calling bilateral_combinations_hold().
+#    ifdef BILATERAL_COMBINATIONS_FLASHMODS
+        if (bilateral_combinations.mods & BILATERAL_COMBINATIONS_FLASHMODS) {
+          // Send a single tap of the modifiers that we previously suppressed
+          // in process_action() before calling bilateral_combinations_hold().
           register_mods(bilateral_combinations.mods);
           unregister_mods(bilateral_combinations.mods);
         }
+#    endif
         bilateral_combinations.active = false;
     }
 }
@@ -439,23 +441,24 @@ void process_action(keyrecord_t *record, action_t action) {
                             }
                         } else {
                             dprint("MODS_TAP: No tap: add_mods\n");
-#    ifdef BILATERAL_COMBINATIONS
-                            if (mods & MOD_MASK_GUI) {
-                              // Don't send GUI modifiers to the computer yet!
+#    ifdef BILATERAL_COMBINATIONS_FLASHMODS
+                            if (mods & BILATERAL_COMBINATIONS_FLASHMODS) {
+                              // Don't send these modifiers to computer yet!
                               // Instead, we'll just set them internally for
                               // bilateral_combinations_hold() to send later.
                               add_mods(mods);
                             }
                             else {
-                              // Send non-GUI modifiers to the computer so
-                              // that mouse clicks with Shift/Ctrl/Alt work.
+                              // Send these modifiers to the computer now so
+                              // that mouse clicks with these modifiers work.
                               register_mods(mods);
                             }
-
-                            // mod-tap hold
-                            bilateral_combinations_hold(action, event);
 #    else
                             register_mods(mods);
+#    endif
+#    ifdef BILATERAL_COMBINATIONS
+                            // mod-tap hold
+                            bilateral_combinations_hold(action, event);
 #    endif
                         }
                     } else {

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -234,6 +234,9 @@ static struct {
 #    if (BILATERAL_COMBINATIONS + 0)
     uint16_t time;
 #    endif
+#    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+    deferred_token defermods;
+#    endif
 } bilateral_combinations = { false };
 
 static bool bilateral_combinations_left(keypos_t key) {
@@ -248,6 +251,15 @@ static bool bilateral_combinations_left(keypos_t key) {
 #    endif
 }
 
+#    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+static uint32_t bilateral_combinations_defermods(uint32_t trigger_time, void *cb_arg) {
+    if (bilateral_combinations.active) {
+        register_mods(bilateral_combinations.mods);
+    }
+    return 0;
+}
+#    endif
+
 static void bilateral_combinations_hold(action_t action, keyevent_t event) {
     dprint("BILATERAL_COMBINATIONS: hold\n");
     bilateral_combinations.active = true;
@@ -258,20 +270,22 @@ static void bilateral_combinations_hold(action_t action, keyevent_t event) {
 #    if (BILATERAL_COMBINATIONS + 0)
     bilateral_combinations.time = event.time;
 #    endif
+#    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+    bilateral_combinations.defermods = defer_exec(BILATERAL_COMBINATIONS_DEFERMODS, bilateral_combinations_defermods, NULL);
+#    endif
+}
+
+static void bilateral_combinations_clear(void) {
+    bilateral_combinations.active = false;
+#    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+    cancel_deferred_exec(bilateral_combinations.defermods);
+#    endif
 }
 
 static void bilateral_combinations_release(uint8_t code) {
     dprint("BILATERAL_COMBINATIONS: release\n");
     if (bilateral_combinations.active && (code == bilateral_combinations.code)) {
-#    ifdef BILATERAL_COMBINATIONS_FLASHMODS
-        if (bilateral_combinations.mods & BILATERAL_COMBINATIONS_FLASHMODS) {
-          // Send a single tap of the modifiers that we previously suppressed
-          // in process_action() before calling bilateral_combinations_hold().
-          register_mods(bilateral_combinations.mods);
-          unregister_mods(bilateral_combinations.mods);
-        }
-#    endif
-        bilateral_combinations.active = false;
+        bilateral_combinations_clear();
     }
 }
 
@@ -282,7 +296,7 @@ static void bilateral_combinations_tap(keyevent_t event) {
 #    if (BILATERAL_COMBINATIONS + 0)
             if (TIMER_DIFF_16(event.time, bilateral_combinations.time) > BILATERAL_COMBINATIONS) {
                 dprint("BILATERAL_COMBINATIONS: timeout\n");
-                bilateral_combinations.active = false;
+                bilateral_combinations_clear();
                 return;
             }
 #    endif
@@ -290,7 +304,7 @@ static void bilateral_combinations_tap(keyevent_t event) {
             unregister_mods(bilateral_combinations.mods);
             tap_code(bilateral_combinations.tap);
         }
-        bilateral_combinations.active = false;
+        bilateral_combinations_clear();
     }
 }
 #endif
@@ -442,18 +456,8 @@ void process_action(keyrecord_t *record, action_t action) {
                             }
                         } else {
                             dprint("MODS_TAP: No tap: add_mods\n");
-#    ifdef BILATERAL_COMBINATIONS_FLASHMODS
-                            if (mods & BILATERAL_COMBINATIONS_FLASHMODS) {
-                              // Don't send these modifiers to computer yet!
-                              // Instead, we'll just set them internally for
-                              // bilateral_combinations_hold() to send later.
-                              add_mods(mods);
-                            }
-                            else {
-                              // Send these modifiers to the computer now so
-                              // that mouse clicks with these modifiers work.
-                              register_mods(mods);
-                            }
+#    if defined(BILATERAL_COMBINATIONS) && (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+                            add_mods(mods);
 #    else
                             register_mods(mods);
 #    endif

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -282,6 +282,7 @@ static void bilateral_combinations_tap(keyevent_t event) {
 #    if (BILATERAL_COMBINATIONS + 0)
             if (TIMER_DIFF_16(event.time, bilateral_combinations.time) > BILATERAL_COMBINATIONS) {
                 dprint("BILATERAL_COMBINATIONS: timeout\n");
+                bilateral_combinations.active = false;
                 return;
             }
 #    endif

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -263,6 +263,12 @@ static void bilateral_combinations_hold(action_t action, keyevent_t event) {
 static void bilateral_combinations_release(uint8_t code) {
     dprint("BILATERAL_COMBINATIONS: release\n");
     if (bilateral_combinations.active && (code == bilateral_combinations.code)) {
+        if (bilateral_combinations.mods & MOD_MASK_GUI) {
+          // Send a single tap of the GUI modifiers to the computer which we
+          // suppressed earlier, before calling bilateral_combinations_hold().
+          register_mods(bilateral_combinations.mods);
+          unregister_mods(bilateral_combinations.mods);
+        }
         bilateral_combinations.active = false;
     }
 }
@@ -433,10 +439,23 @@ void process_action(keyrecord_t *record, action_t action) {
                             }
                         } else {
                             dprint("MODS_TAP: No tap: add_mods\n");
-                            register_mods(mods);
 #    ifdef BILATERAL_COMBINATIONS
+                            if (mods & MOD_MASK_GUI) {
+                              // Don't send GUI modifiers to the computer yet!
+                              // Instead, we'll just set them internally for
+                              // bilateral_combinations_hold() to send later.
+                              add_mods(mods);
+                            }
+                            else {
+                              // Send non-GUI modifiers to the computer so
+                              // that mouse clicks with Shift/Ctrl/Alt work.
+                              register_mods(mods);
+                            }
+
                             // mod-tap hold
                             bilateral_combinations_hold(action, event);
+#    else
+                            register_mods(mods);
 #    endif
                         }
                     } else {


### PR DESCRIPTION
This fixes a glitch in Miryoku's bilateral-combinations implementation
where the GUI modifiers in a mod-tap key combination are always sent to
the computer alongside the combination, interrupting the user's typing.

For example, suppose you held `LGUI_T(KC_A)` and then pressed `KC_R` with
the same hand (assuming your left hand on the standard QWERTY layout).

Before this patch, the combination sends `KC_LGUI` to the computer when
`LGUI_T(KC_A)` is held, followed by `KC_A` and `KC_R` when finally released.
This inadvertently triggers whatever action is associated with `KC_LGUI`
on the computer, such as opening the "Start Menu" in Microsoft Windows.

With this patch applied, the combination doesn't send `KC_LGUI` to the
computer when `LGUI_T(KC_A)` is held.  Instead, it applies the `KC_LGUI`
modifier *internally* for `bilateral_combinations_hold()` and therefore
only sends out `KC_A` and `KC_R` to the computer as the user would expect.

However, note that non-GUI modifiers such as Shift/Ctrl/Alt are still
sent to the computer for unilateral mod-tap combinations to allow for
modified mouse clicks such as Shift-click, Ctrl-click, Alt-click, etc.