### PR TITLE
Crossover bilateral combinations for dual-hand chords and rolls

### DIFF
--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -197,16 +197,18 @@ If `BILATERAL_COMBINATIONS` is defined to a value, hold times greater than that 
 #define BILATERAL_COMBINATIONS 500
 ```
 
-To suppress "flashing mods" such as the GUI keys (which pop up the "Start Menu" in Microsoft Windows) during bilateral combinations, add the following to your `config.h`:
+To delay the registration of modifiers (such as `KC_LGUI` and `KC_RGUI`, which are considered to be "flashing mods" because they suddenly "flash" or pop up the "Start Menu" in Microsoft Windows) during bilateral combinations:
+
+1. Add the following line to your `config.h` and define a timeout value (measured in milliseconds).  Hold times greater than this value will permit modifiers to be registered.
 
 ```c
-#define BILATERAL_COMBINATIONS_FLASHMODS MOD_MASK_GUI
+#define BILATERAL_COMBINATIONS_DEFERMODS 100
 ```
 
-In addition, to also suppress the Alt keys (which pop up the "Ribbon Menu" in Microsoft Office) during bilateral combinations, specify a compound mask.  For example:
+2. Add the following line to your `rules.mk` file to enable QMK's deferred execution facility, which is needed by the `BILATERAL_COMBINATIONS_DEFERMODS` setting mentioned above.
 
-```c
-#define BILATERAL_COMBINATIONS_FLASHMODS (MOD_MASK_GUI|MOD_MASK_ALT)
+```make
+DEFERRED_EXEC_ENABLE = yes
 ```
 
 To monitor activations in the background, enable debugging, enable the console, enable terminal bell, add `#define DEBUG_ACTION` to `config.h`, and use something like the following shell command line:

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -197,6 +197,18 @@ If `BILATERAL_COMBINATIONS` is defined to a value, hold times greater than that 
 #define BILATERAL_COMBINATIONS 500
 ```
 
+To suppress "flashing mods" such as the GUI keys (which pop up the "Start Menu" in Microsoft Windows) during bilateral combinations, add the following to your `config.h`:
+
+```c
+#define BILATERAL_COMBINATIONS_FLASHMODS MOD_MASK_GUI
+```
+
+In addition, to also suppress the Alt keys (which pop up the "Ribbon Menu" in Microsoft Office) during bilateral combinations, specify a compound mask.  For example:
+
+```c
+#define BILATERAL_COMBINATIONS_FLASHMODS (MOD_MASK_GUI|MOD_MASK_ALT)
+```
+
 To monitor activations in the background, enable debugging, enable the console, enable terminal bell, add `#define DEBUG_ACTION` to `config.h`, and use something like the following shell command line:
 
 ```sh

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -211,6 +211,12 @@ To delay the registration of modifiers (such as `KC_LGUI` and `KC_RGUI`, which a
 DEFERRED_EXEC_ENABLE = yes
 ```
 
+To enable *crossover* bilateral combinations (which start on one side of the keyboard and cross over to the other side, such as `RSFT_T(KC_J)` and `LGUI_T(KC_A)` in the word "jam"), add the following line to your `config.h` and define a value: hold times greater than that value will permit crossover bilateral combinations.  For example, if you typed `RSFT_T(KC_J)` and `LGUI_T(KC_A)` faster than the defined value, the keys `KC_J` and `KC_A` would be sent to the computer.  In contrast, if you typed slower than the defined value, the keys `RSFT(KC_A)` would be sent to the computer.
+
+```c
+#define BILATERAL_COMBINATIONS_CROSSOVER 75
+```
+
 To monitor activations in the background, enable debugging, enable the console, enable terminal bell, add `#define DEBUG_ACTION` to `config.h`, and use something like the following shell command line:
 
 ```sh

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -263,12 +263,14 @@ static void bilateral_combinations_hold(action_t action, keyevent_t event) {
 static void bilateral_combinations_release(uint8_t code) {
     dprint("BILATERAL_COMBINATIONS: release\n");
     if (bilateral_combinations.active && (code == bilateral_combinations.code)) {
-        if (bilateral_combinations.mods & MOD_MASK_GUI) {
-          // Send a single tap of the GUI modifiers to the computer which we
-          // suppressed earlier, before calling bilateral_combinations_hold().
+#    ifdef BILATERAL_COMBINATIONS_FLASHMODS
+        if (bilateral_combinations.mods & BILATERAL_COMBINATIONS_FLASHMODS) {
+          // Send a single tap of the modifiers that we previously suppressed
+          // in process_action() before calling bilateral_combinations_hold().
           register_mods(bilateral_combinations.mods);
           unregister_mods(bilateral_combinations.mods);
         }
+#    endif
         bilateral_combinations.active = false;
     }
 }
@@ -439,23 +441,24 @@ void process_action(keyrecord_t *record, action_t action) {
                             }
                         } else {
                             dprint("MODS_TAP: No tap: add_mods\n");
-#    ifdef BILATERAL_COMBINATIONS
-                            if (mods & MOD_MASK_GUI) {
-                              // Don't send GUI modifiers to the computer yet!
+#    ifdef BILATERAL_COMBINATIONS_FLASHMODS
+                            if (mods & BILATERAL_COMBINATIONS_FLASHMODS) {
+                              // Don't send these modifiers to computer yet!
                               // Instead, we'll just set them internally for
                               // bilateral_combinations_hold() to send later.
                               add_mods(mods);
                             }
                             else {
-                              // Send non-GUI modifiers to the computer so
-                              // that mouse clicks with Shift/Ctrl/Alt work.
+                              // Send these modifiers to the computer now so
+                              // that mouse clicks with these modifiers work.
                               register_mods(mods);
                             }
-
-                            // mod-tap hold
-                            bilateral_combinations_hold(action, event);
 #    else
                             register_mods(mods);
+#    endif
+#    ifdef BILATERAL_COMBINATIONS
+                            // mod-tap hold
+                            bilateral_combinations_hold(action, event);
 #    endif
                         }
                     } else {

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -234,6 +234,9 @@ static struct {
 #    if (BILATERAL_COMBINATIONS + 0)
     uint16_t time;
 #    endif
+#    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+    deferred_token defermods;
+#    endif
 } bilateral_combinations = { false };
 
 static bool bilateral_combinations_left(keypos_t key) {
@@ -248,6 +251,15 @@ static bool bilateral_combinations_left(keypos_t key) {
 #    endif
 }
 
+#    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+static uint32_t bilateral_combinations_defermods(uint32_t trigger_time, void *cb_arg) {
+    if (bilateral_combinations.active) {
+        register_mods(bilateral_combinations.mods);
+    }
+    return 0;
+}
+#    endif
+
 static void bilateral_combinations_hold(action_t action, keyevent_t event) {
     dprint("BILATERAL_COMBINATIONS: hold\n");
     bilateral_combinations.active = true;
@@ -258,20 +270,22 @@ static void bilateral_combinations_hold(action_t action, keyevent_t event) {
 #    if (BILATERAL_COMBINATIONS + 0)
     bilateral_combinations.time = event.time;
 #    endif
+#    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+    bilateral_combinations.defermods = defer_exec(BILATERAL_COMBINATIONS_DEFERMODS, bilateral_combinations_defermods, NULL);
+#    endif
+}
+
+static void bilateral_combinations_clear(void) {
+    bilateral_combinations.active = false;
+#    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+    cancel_deferred_exec(bilateral_combinations.defermods);
+#    endif
 }
 
 static void bilateral_combinations_release(uint8_t code) {
     dprint("BILATERAL_COMBINATIONS: release\n");
     if (bilateral_combinations.active && (code == bilateral_combinations.code)) {
-#    ifdef BILATERAL_COMBINATIONS_FLASHMODS
-        if (bilateral_combinations.mods & BILATERAL_COMBINATIONS_FLASHMODS) {
-          // Send a single tap of the modifiers that we previously suppressed
-          // in process_action() before calling bilateral_combinations_hold().
-          register_mods(bilateral_combinations.mods);
-          unregister_mods(bilateral_combinations.mods);
-        }
-#    endif
-        bilateral_combinations.active = false;
+        bilateral_combinations_clear();
     }
 }
 
@@ -282,7 +296,7 @@ static void bilateral_combinations_tap(keyevent_t event) {
 #    if (BILATERAL_COMBINATIONS + 0)
             if (TIMER_DIFF_16(event.time, bilateral_combinations.time) > BILATERAL_COMBINATIONS) {
                 dprint("BILATERAL_COMBINATIONS: timeout\n");
-                bilateral_combinations.active = false;
+                bilateral_combinations_clear();
                 return;
             }
 #    endif
@@ -290,7 +304,7 @@ static void bilateral_combinations_tap(keyevent_t event) {
             unregister_mods(bilateral_combinations.mods);
             tap_code(bilateral_combinations.tap);
         }
-        bilateral_combinations.active = false;
+        bilateral_combinations_clear();
     }
 }
 #endif
@@ -442,18 +456,8 @@ void process_action(keyrecord_t *record, action_t action) {
                             }
                         } else {
                             dprint("MODS_TAP: No tap: add_mods\n");
-#    ifdef BILATERAL_COMBINATIONS_FLASHMODS
-                            if (mods & BILATERAL_COMBINATIONS_FLASHMODS) {
-                              // Don't send these modifiers to computer yet!
-                              // Instead, we'll just set them internally for
-                              // bilateral_combinations_hold() to send later.
-                              add_mods(mods);
-                            }
-                            else {
-                              // Send these modifiers to the computer now so
-                              // that mouse clicks with these modifiers work.
-                              register_mods(mods);
-                            }
+#    if defined(BILATERAL_COMBINATIONS) && (BILATERAL_COMBINATIONS_DEFERMODS + 0)
+                            add_mods(mods);
 #    else
                             register_mods(mods);
 #    endif

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -47,7 +47,7 @@ int retro_tapping_counter = 0;
 #    include <fauxclicky.h>
 #endif
 
-#if (BILATERAL_COMBINATIONS + 0)
+#if (BILATERAL_COMBINATIONS + BILATERAL_COMBINATIONS_CROSSOVER + 0)
 #    include "quantum.h"
 #endif
 
@@ -231,7 +231,7 @@ static struct {
     uint8_t tap;
     uint8_t mods;
     bool left;
-#    if (BILATERAL_COMBINATIONS + 0)
+#    if (BILATERAL_COMBINATIONS + BILATERAL_COMBINATIONS_CROSSOVER + 0)
     uint16_t time;
 #    endif
 #    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
@@ -267,7 +267,7 @@ static void bilateral_combinations_hold(action_t action, keyevent_t event) {
     bilateral_combinations.tap = action.layer_tap.code;
     bilateral_combinations.mods = (action.kind.id == ACT_LMODS_TAP) ? action.key.mods : action.key.mods << 4;
     bilateral_combinations.left = bilateral_combinations_left(event.key);
-#    if (BILATERAL_COMBINATIONS + 0)
+#    if (BILATERAL_COMBINATIONS + BILATERAL_COMBINATIONS_CROSSOVER + 0)
     bilateral_combinations.time = event.time;
 #    endif
 #    if (BILATERAL_COMBINATIONS_DEFERMODS + 0)
@@ -304,6 +304,18 @@ static void bilateral_combinations_tap(keyevent_t event) {
             unregister_mods(bilateral_combinations.mods);
             tap_code(bilateral_combinations.tap);
         }
+#    if (BILATERAL_COMBINATIONS_CROSSOVER + 0)
+        else {
+            if (TIMER_DIFF_16(event.time, bilateral_combinations.time) > BILATERAL_COMBINATIONS_CROSSOVER) {
+                dprint("BILATERAL_COMBINATIONS_CROSSOVER: timeout\n");
+                bilateral_combinations_clear();
+                return;
+            }
+            dprint("BILATERAL_COMBINATIONS_CROSSOVER: change\n");
+            unregister_mods(bilateral_combinations.mods);
+            tap_code(bilateral_combinations.tap);
+        }
+#    endif
         bilateral_combinations_clear();
     }
 }

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -282,6 +282,7 @@ static void bilateral_combinations_tap(keyevent_t event) {
 #    if (BILATERAL_COMBINATIONS + 0)
             if (TIMER_DIFF_16(event.time, bilateral_combinations.time) > BILATERAL_COMBINATIONS) {
                 dprint("BILATERAL_COMBINATIONS: timeout\n");
+                bilateral_combinations.active = false;
                 return;
             }
 #    endif

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -263,6 +263,12 @@ static void bilateral_combinations_hold(action_t action, keyevent_t event) {
 static void bilateral_combinations_release(uint8_t code) {
     dprint("BILATERAL_COMBINATIONS: release\n");
     if (bilateral_combinations.active && (code == bilateral_combinations.code)) {
+        if (bilateral_combinations.mods & MOD_MASK_GUI) {
+          // Send a single tap of the GUI modifiers to the computer which we
+          // suppressed earlier, before calling bilateral_combinations_hold().
+          register_mods(bilateral_combinations.mods);
+          unregister_mods(bilateral_combinations.mods);
+        }
         bilateral_combinations.active = false;
     }
 }
@@ -433,10 +439,23 @@ void process_action(keyrecord_t *record, action_t action) {
                             }
                         } else {
                             dprint("MODS_TAP: No tap: add_mods\n");
-                            register_mods(mods);
 #    ifdef BILATERAL_COMBINATIONS
+                            if (mods & MOD_MASK_GUI) {
+                              // Don't send GUI modifiers to the computer yet!
+                              // Instead, we'll just set them internally for
+                              // bilateral_combinations_hold() to send later.
+                              add_mods(mods);
+                            }
+                            else {
+                              // Send non-GUI modifiers to the computer so
+                              // that mouse clicks with Shift/Ctrl/Alt work.
+                              register_mods(mods);
+                            }
+
                             // mod-tap hold
                             bilateral_combinations_hold(action, event);
+#    else
+                            register_mods(mods);
 #    endif
                         }
                     } else {


### PR DESCRIPTION
Thanks to the increased typing speed made possible by PR #48, I discovered a blind spot in the bilateral combinations concept and patched it in a new optional feature called *"crossover"* bilateral combinations (implemented in this PR) to catch fast "rolls" that cross the left/right keyboard boundary.  For example, imagine that you had Miryoku-style home row mods on the standard QWERTY layout so that typing the word "jam" involves the `RSFT_T(KC_J)` and `LGUI_T(KC_A)` keys.  :point_right: Regular bilateral combinations would ignore this combination since the keys are located on different sides of the keyboard, thereby sending `RSFT(KC_A)` to the computer.  :point_up: In contrast, crossover bilateral combinations catch this combination (if you're quick enough, according to a configurable timeout) and send `KC_J` and `KC_A` to the computer, thus avoiding accidental mods.

> To enable *crossover* bilateral combinations (which start on one side of the keyboard and cross over to the other side, such as `RSFT_T(KC_J)` and `LGUI_T(KC_A)` in the word "jam"), add the following line to your `config.h` and define a value: hold times greater than that value will permit crossover bilateral combinations.  For example, if you typed `RSFT_T(KC_J)` and `LGUI_T(KC_A)` faster than the defined value, the keys `KC_J` and `KC_A` would be sent to the computer.  In contrast, if you typed slower than the defined value, the keys `RSFT(KC_A)` would be sent to the computer.
> 
> ```c
> #define BILATERAL_COMBINATIONS_CROSSOVER 75
> ```
> 

Here is the relevant portion of my `config.h` file which activates both patches to provide the best typing experience I've felt since switching to Miryoku's home row mods ~2 years ago, as detailed in [*Taming home row mods with Bilateral Combinations*](https://sunaku.github.io/home-row-mods.html):

```c
/* QMK */
#define TAPPING_TERM 200
#define IGNORE_MOD_TAP_INTERRUPT

/* Miryoku */
#define BILATERAL_COMBINATIONS
#define BILATERAL_COMBINATIONS_CROSSOVER 75
#define BILATERAL_COMBINATIONS_DEFERMODS 100
```

You also need to add the following line to your `rules.mk` file to enable [QMK's deferred execution](https://docs.qmk.fm/#/custom_quantum_functions?id=deferred-execution) facility, used by DeferMods:

```make
DEFERRED_EXEC_ENABLE = yes
```

**_Note:_** QMK's deferred execution feature was introduced **1 year later** (on 16 November 2021 in commit 36d123e9c5a9ce0e29b9bc22ef87661bf479e299) after the latest in Miryoku's bilateral-combinations branch!  So in order to try out my latest changes, you'll need to update this branch to a more recent version of mainline QMK.  I've already done this (resolving merge conflicts) in [a separate branch based on 0.18.6](https://github.com/sunaku/qmk_firmware/commits/bilateral-combinations-crossover-0.18.6), so simply check out that branch and configure your `config.h` and `rules.mk` files (as I've documented previously) to try it out.